### PR TITLE
Missing Enums: Converted .Java Enums to .kt

### DIFF
--- a/app/src/main/java/com/example/campuswrapper/structure/exam/ExamMode.kt
+++ b/app/src/main/java/com/example/campuswrapper/structure/exam/ExamMode.kt
@@ -1,0 +1,5 @@
+package com.example.campuswrapper.structure.exam;
+
+enum class ExamMode {
+    DIGITAL, PEN_PAPER, VERBAL_PAPER, ROPE, UNKNOWN
+}

--- a/app/src/main/java/com/example/campuswrapper/structure/exam/ExamNotes.kt
+++ b/app/src/main/java/com/example/campuswrapper/structure/exam/ExamNotes.kt
@@ -1,0 +1,5 @@
+package com.example.campuswrapper.structure.exam;
+
+enum class ExamNotes {
+    NONE, SOME, ALLOWED, UNKNOWN
+}


### PR DESCRIPTION
Converted the ExamMode and ExamNotes enums from .java to .kt