### PR TITLE
Project Stability: handled case when no data is stored

### DIFF
--- a/app/src/main/java/com/example/campuswrapper/handlers/StorageHandler.kt
+++ b/app/src/main/java/com/example/campuswrapper/handlers/StorageHandler.kt
@@ -37,7 +37,8 @@ object StorageHandler {
 
         val typeOfHashMap: Type = object : TypeToken<ArrayList<Lecture>>() {}.type
 
-        val data = getLocal(file_detailed_lecturs)
+        val data = getLocal(file_detailed_lecturs) ?: return ArrayList()
+        
         val lectures = Gson().fromJson(data, typeOfHashMap) as ArrayList<Lecture>
         Log.d(LogHandler.appStorageTag, "Loaded ${lectures.size} lectures from local-storage")
 


### PR DESCRIPTION
When the app is initially started, thus has no local file, the app crashed. This case has now been handled, by returning an empty list of, when there is no file.